### PR TITLE
fix: negative with double star (!**)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,17 @@ async function main() {
 }
 
 export function pathMatch(changedFiles: string[], paths_pattern: string[]): string[] {
-   return micromatch.match(changedFiles, paths_pattern, {dot: true});
+    // workaround for negative match
+    const workaround_pattern: string[] = [];
+    for (const pattern of paths_pattern) {
+        if (pattern.startsWith('!**')) {
+            workaround_pattern.push("!" + "(" + pattern.substring(1) + ")");
+        } else {
+            workaround_pattern.push(pattern);
+        }
+    }
+
+    return micromatch.match(changedFiles, workaround_pattern, {dot: true});
 }
 
 export function ignoreFilter(changedFiles: string[], paths_pattern: string[]): string[] {

--- a/test/match.test.ts
+++ b/test/match.test.ts
@@ -22,6 +22,12 @@ describe("is match api test", () => {
             expect(result).toBe(true);
         }
 
+        // FIXME: !**.js now return true, we need a workaround to make it return false
+        {
+            const result = isMatch("src/a/b/index.js", "!**.js");
+            expect(result).toBe(true);
+        }
+
     });
 
     test("multiple patterns", () => {

--- a/test/path.test.ts
+++ b/test/path.test.ts
@@ -44,6 +44,23 @@ describe("path filter", () => {
         let files = pathMatch(changedFiles, paths);
         expect(files).to.deep.equal([]);
     });
+
+    test("negative with * match", () => {
+        let files = pathMatch(["d.js"], ["!*.js"]);
+        expect(files).to.deep.equal([]);
+    });
+
+    // TODO: !**.js now return true, we make a workaround to let it return false
+    test("negative with ** match (workaround)", () => {
+        let files = pathMatch(["a/b/c/d.js"], ["!**.js"]);
+        expect(files).to.deep.equal([]);
+    });
+
+    test("negative with glob match override previous positive match", () => {
+        let paths = ["**.yml", "!**/test.yml"];
+        let files = pathMatch(changedFiles, paths);
+        expect(files).to.deep.equal([".github/workflows/main.yml"]);
+    });
 })
 
 


### PR DESCRIPTION
github support !**.md to exclude all md files. but micromatch return true for this case. So we make a workaround and test case for this case.

```javascript
// FIXME: !**.js now return true, we need a workaround to make it return false
{
    const result = isMatch("src/a/b/index.js", "!**.js");
    expect(result).toBe(true);  // we expect false. !(**.js) will return false.
}
```